### PR TITLE
Give Sisyphus and QC conf as HTTP input

### DIFF
--- a/config/app.config
+++ b/config/app.config
@@ -7,5 +7,5 @@ report_bin: /opt/siswrap/deps/sisyphus/quickReport.pl
 qc_bin: /opt/siswrap/deps/sisyphus/qcValidateRun.pl
 version_bin: /opt/siswrap/deps/sisyphus/version.pl
 qc_file: /srv/qc_config/sisyphus_qc.xml
-runfolder_root: /data/testarteria1/mon1/
+runfolder_root: /data/testarteria1/mon1
 perl: /usr/bin/perl

--- a/siswrap/handlers.py
+++ b/siswrap/handlers.py
@@ -1,9 +1,10 @@
 import jsonpickle
+import json
 import arteria
 from arteria.web.handlers import BaseRestHandler
 from arteria.web.state import State
 from wrapper_services import ProcessService, Wrapper, ProcessInfo
-from siswrap import __version__ as version
+from siswrap import __version__ as siswrap_version
 
 
 class BaseSiswrapHandler(BaseRestHandler):
@@ -31,18 +32,14 @@ class BaseSiswrapHandler(BaseRestHandler):
         reason = "OK"
 
         # Write output for specific process
-        if type(proc_info) is dict:
-            state = proc_info.get("state")
+        state = proc_info.get("state")
 
-            if state == State.STARTED:
-                reason = "OK - still processing"
-            elif state == State.DONE:
-                reason = "OK - finished processing"
-            elif state == State.ERROR:
-                reason = "OK - but an error occured while processing"
-            else:
-                http_code = self.HTTP_ERROR
-                reason = "An unexpected error occured"
+        if state == State.STARTED:
+            reason = "OK - still processing"
+        elif state == State.DONE:
+            reason = "OK - finished processing"
+        elif state == State.ERROR:
+            reason = "OK - but an error occured while processing"
         # Write output for all processes
         else:
             reason = "OK"
@@ -84,13 +81,51 @@ class RunHandler(BaseSiswrapHandler):
     """ Our handler for requesting the launch of a new quick report and
         quality control.
     """
+
+    def setup_wrapper_parameters(self, wrapper_type):
+        """ Setups the input parameters to the wrapper type in question by
+            parsing the HTTP request body.
+
+            Args:
+                wrapper_type: specifies whether or not to look for a qc_config
+                              in the body.
+
+            Returns:
+                A dict with the runfolder, and if given: the Sisyphus config and
+                the QC config.
+        """
+
+        params = {}
+        expect_param = ["runfolder"]
+
+        if wrapper_type == "qc":
+            expect_param = expect_param + ["qc_config"]
+
+        body = self.body_as_object(expect_param)
+
+        params["runfolder"] = body["runfolder"].strip()
+
+        if wrapper_type == "qc":
+            params["qc_config"] = body["qc_config"].strip()
+
+        body = json.loads(self.request.body)
+
+        if "sisyphus_config" in body:
+            params["sisyphus_config"] = body["sisyphus_config"].strip()
+
+        return params
+
     def post(self, runfolder="/some/runfolder"):
         """ Start running Sisyphus quick report or quality control for specific
             runfolder.
 
             Args:
                 runfolder: Which runfolder to generate a report or quality
-                           control for.
+                           control for. (mandatory)
+                qc_config: Supply a custom QC XML config file that will be copied into
+                           Sisyphus root folder (mandatory for QC actions)
+                sisyphus_config: Supply a custom YAML config file that will overwrite then
+                                 default bundled in Sisyphus. (optional)
 
             Returns:
                 A status code HTTP 202 if the report generation or quality control
@@ -103,18 +138,10 @@ class RunHandler(BaseSiswrapHandler):
         """
         try:
             url = self.request.uri.strip()
-
-            expect_param = ["runfolder"]
-            body = self.body_as_object(expect_param)
-            runfolder = body["runfolder"].strip()
-
-            # Return a new wrapper object depending on what was requested in
-            # the URL, and then ask the process service to start execution.
             wrapper_type = Wrapper.url_to_type(url)
-            wrapper = Wrapper.new_wrapper(wrapper_type, str(runfolder),
-                                          self.config_svc)
-            sisyphus_version = wrapper.sisyphus_version()
-            my_version = version
+            wrapper_params = self.setup_wrapper_parameters(wrapper_type)
+
+            wrapper = Wrapper.new_wrapper(wrapper_type, wrapper_params, self.config_svc)
             result = self.process_svc.run(wrapper)
 
             self.append_status_link(result)
@@ -124,8 +151,9 @@ class RunHandler(BaseSiswrapHandler):
                     "runfolder": result.info.runfolder,
                     "link": result.info.link,
                     "msg": result.info.msg,
-                    "service_version": my_version,
-                    "sisyphus_version": sisyphus_version}
+                    "service_version": siswrap_version,
+                    "sisyphus_version": wrapper.sisyphus_version()}
+
             self.write_accepted(resp)
         except RuntimeError, err:
             self.write_object("An error ocurred: " + str(err),
@@ -172,6 +200,6 @@ class StatusHandler(BaseSiswrapHandler):
             else:
                 # If a specific PID wasn't requested then return all
                 # processes of the specific wrapper type
-                self.write_status(self.process_svc.get_all(wrapper_type))
+                self.write_status({"statuses": self.process_svc.get_all(wrapper_type)})
         except RuntimeError, err:
             self.write_object("An error occurred: " + str(err))

--- a/siswrap/wrapper_services.py
+++ b/siswrap/wrapper_services.py
@@ -83,29 +83,70 @@ class Wrapper(object):
         QualityControl at the moment).
 
         Args:
-            runfolder: the name of the runfolder to use (not full path)
-            configuration_svc: the ConfigurationService for our config lookups
-            logger: logger object for printouts
+            params: Dict of parameters to the wrapper. Must contain the name of
+                    the runfolder to use (not full path). Can contain a YAML
+                    object containing the Sisyphus config to use, and a XML
+                    object cotaining the QC config to use.
+            configuration_svc: The ConfigurationService for our config lookups
+            logger: Logger object for printouts
 
-        FIXME: Raises
+        Raises:
+            OSError: If the given runfolder doesn't exist.
     """
 
     QC_TYPE = "qc"
     REPORT_TYPE = "report"
 
-    def __init__(self, runfolder, configuration_svc, logger=None):
+    def __init__(self, params, configuration_svc, logger=None):
+        self.conf_svc = configuration_svc
+        self.logger = logger or logging.getLogger(__name__)
+
         conf = configuration_svc.get_app_config()
-        runpath = conf["runfolder_root"] + runfolder
+        runpath = conf["runfolder_root"] + "/" + params["runfolder"]
 
         if not os.path.isdir(runpath):
             raise OSError("No runfolder {0} exists.".format(runpath))
 
         self.info = ProcessInfo(runpath)
-        self.conf_svc = configuration_svc
-        self.logger = logger or logging.getLogger(__name__)
+
+        if "sisyphus_config" in params:
+            path = runpath + "/sisyphus.yml"
+            self.write_new_config_file(path, params["sisyphus_config"])
+
 
     def __get_attr__(self, attr):
         return getattr(self.info, attr)
+
+    @staticmethod
+    def write_new_config_file(path, content):
+        """ Writes new config file (especially used for Sisyphus YAML and QC XML).
+            If the file already exists a backup copy will be created.
+
+            Args:
+                - path: The path to the config file that should be written.
+                - content: The content of the new config file.
+        """
+        try:
+            import shutil
+            import datetime
+
+            logger = logging.getLogger(__name__)
+
+            logger.debug("Writing new config file " + path)
+
+            now = datetime.datetime.now().isoformat()
+
+            if os.path.isfile(path):
+                logger.debug("Config file already existed. Making backup copy.")
+                shutil.move(path, path + "." + now)
+
+            with open(path, "w") as f:
+                f.write(content)
+
+        except OSError, err:
+            logger.error("Error writing new config file {0}: {1}".
+                              format(path, err))
+
 
     def sisyphus_version(self):
         """
@@ -178,24 +219,29 @@ class ReportWrapper(Wrapper):
         base class Wrapper.
 
         Args:
-            runfolder: the runfolder to start processing (not full path)
+            params: Dict of parameters to the wrapper. Must contain the name of
+                    the runfolder to use (not full path). Can contain a YAML
+                    object containing the Sisyphus config to use.
             configuration_svc: the ConfigurationService for our conf lookups
             logger: the Logger object in charge of logging output
     """
 
-    def __init__(self, runfolder, configuration_svc):
-        super(ReportWrapper, self).__init__(runfolder,
-                                            configuration_svc)
+    def __init__(self, params, configuration_svc, logger=None):
+        super(ReportWrapper, self).__init__(params, configuration_svc, logger)
         self.binary_conf_lookup = "report_bin"
         self.type_txt = Wrapper.REPORT_TYPE
-
 
 class QCWrapper(Wrapper):
     """ Wrapper around the QualityControl perl script. Inherits behaviour from
         its base class Wrapper.
 
          Args:
-             runfolder: the runfolder to start processing (not full path)
+            params: Dict of parameters to the wrapper. Must contain the name of
+                    the runfolder to use (not full path). Can contain a YAML
+                    object containing the Sisyphus config to use, and a XML
+                    object containing the QC config to use. If a config is given
+                    then they will be written to the runfolder where Sisyphus
+                    will be able to use them.
              configuration_svc: ConfigurationService serving our conf lookups
              logger: the Logger object in charge of logging output
 
@@ -203,23 +249,15 @@ class QCWrapper(Wrapper):
             IOError: if we couldn't copy the QC settings input file
      """
 
-    def __init__(self, runfolder, configuration_svc, logger=None):
-        super(QCWrapper, self).__init__(runfolder, configuration_svc)
+    def __init__(self, params, configuration_svc, logger=None):
+        super(QCWrapper, self).__init__(params, configuration_svc, logger)
         self.binary_conf_lookup = "qc_bin"
         self.type_txt = Wrapper.QC_TYPE
-        self.logger = logger or logging.getLogger(__name__)
+        conf = self.conf_svc.get_app_config()
 
-        try:
-            # Copy QC settings file from central server location (provisioned
-            # from elsewhere) to current runfolder destination
-            import shutil
-            conf = self.conf_svc.get_app_config()
-            src = conf["qc_file"]
-            dst = conf["runfolder_root"] + runfolder + "/sisyphus_qc.xml"
-            shutil.copyfile(src, dst)
-        except IOError, err:
-            self.logger.error("Couldn't copy file {0} to {1}: {2}".
-                              format(src, dst, err))
+        if "qc_config" in params:
+            path = conf["runfolder_root"] + "/" + params["runfolder"] + "/sisyphus_qc.xml"
+            self.write_new_config_file(path, params["qc_config"])
 
 
 class ProcessService(object):
@@ -386,8 +424,8 @@ class ProcessService(object):
                 wrapper_type: the object type to check statuses for
 
             Returns:
-                a list of processes and some meta information if they are running, otherwise
-                an empty list
+                a dict of processes and some meta information if they are running, otherwise
+                an empty dict
         """
         # Only update processes of our requested wrapper class
         map(lambda pid: self.poll_process(pid)

--- a/tests/unit/siswrap_handlers_tests.py
+++ b/tests/unit/siswrap_handlers_tests.py
@@ -6,6 +6,7 @@ from arteria.configuration import ConfigurationService
 from siswrap.app import *
 from siswrap.handlers import *
 from siswrap.wrapper_services import *
+from siswrap_test_helpers import *
 
 
 # Some unit tests for siswrap.handlers
@@ -41,13 +42,43 @@ def stub_sisyphus_version(monkeypatch):
 def json(payload):
     return jsonpickle.encode(payload)
 
+@pytest.fixture
+def stub_new_sisyphus_conf(monkeypatch):
+    def my_new_config(self, path, content):
+        assert path == "/data/testarteria1/mon1/foo/sisyphus.yml"
+        assert content == TestHelpers.SISYPHUS_CONFIG
+
+    monkeypatch.setattr("siswrap.wrapper_services.Wrapper.write_new_config_file", my_new_config)
+
+@pytest.fixture
+def stub_new_qc_conf(monkeypatch):
+    def my_new_config(self, path, content):
+        assert path == "/data/testarteria1/mon1/foo/sisyphus_qc.xml"
+        assert content == TestHelpers.QC_CONFIG
+
+    monkeypatch.setattr("siswrap.wrapper_services.Wrapper.write_new_config_file", my_new_config)
 
 class TestRunHandler(object):
 
     @pytest.mark.gen_test
-    def test_post_job(self, http_client, http_server, base_url, stub_isdir, stub_sisyphus_version):
-        payload = {"runfolder": "foo"}
+    def test_post_report_job(self, http_client, http_server, base_url, stub_isdir, stub_sisyphus_version, stub_new_sisyphus_conf):
+        payload = {"runfolder": "foo", "sisyphus_config": TestHelpers.SISYPHUS_CONFIG}
+
         resp = yield http_client.fetch(base_url + API_URL + "/report/run/123",
+                                       method="POST", body=json(payload))
+
+        assert resp.code == 202
+        payload = jsonpickle.decode(resp.body)
+        assert payload["sisyphus_version"] == "15.3.2"
+        from siswrap import __version__ as version
+        assert payload["service_version"] == version
+        assert payload["runfolder"] == "/data/testarteria1/mon1/foo"
+
+    @pytest.mark.gen_test
+    def test_post_qc_job(self, http_client, http_server, base_url, stub_isdir, stub_sisyphus_version, stub_new_qc_conf):
+        payload = {"runfolder": "foo", "qc_config": TestHelpers.QC_CONFIG}
+
+        resp = yield http_client.fetch(base_url + API_URL + "/qc/run/123",
                                        method="POST", body=json(payload))
 
         assert resp.code == 202
@@ -90,8 +121,8 @@ class TestStatusHandler(object):
         resp = yield http_client.fetch(base_url + API_URL + "/report/status/")
         assert resp.code == 200
         payload = jsonpickle.decode(resp.body)
-        assert payload["process_info"][0]["pid"] == 4242
-        assert payload["process_info"][1]["pid"] == 3131
+        assert payload["statuses"][0]["pid"] == 4242
+        assert payload["statuses"][1]["pid"] == 3131
 
     @pytest.mark.gen_test
     def test_get_existing_status(self, http_client, http_server,
@@ -109,13 +140,13 @@ class TestStatusHandler(object):
         assert resp.code == 200
         payload = jsonpickle.decode(resp.body)
         print payload
-        assert payload["process_info"]["pid"] == 123
-        assert payload["process_info"]["state"] == State.STARTED
+        assert payload["pid"] == 123
+        assert payload["state"] == State.STARTED
 
         resp = yield http_client.fetch(base_url + API_URL + "/qc/status/321")
         assert resp.code == 200
         payload = jsonpickle.decode(resp.body)
-        assert payload["process_info"]["pid"] == 321
+        assert payload["pid"] == 321
 
     @pytest.mark.gen_test
     def test_get_invalid_status(self, http_client, http_server,

--- a/tests/unit/siswrap_test_helpers.py
+++ b/tests/unit/siswrap_test_helpers.py
@@ -1,0 +1,251 @@
+#import pytest
+#import tornado.web
+#import jsonpickle
+#from arteria import *
+#from arteria.configuration import ConfigurationService
+#from siswrap.app import *
+#from siswrap.handlers import *
+#from siswrap.wrapper_services import *
+
+
+class TestHelpers(object):
+
+    SISYPHUS_CONFIG = """MISMATCH:
+        1: 1
+        2: 1
+        3: 1
+        4: 1
+        5: 1
+        6: 1
+        7: 1
+        8: 1
+
+# The host on which to put the summaries
+SUMMARY_HOST: mm-xlas002
+
+# The directory on ARCHIVE_HOST to put the runfolder in
+SUMMARY_PATH: /mnt/Seq-Summaries/2015/
+
+# The path, relative to the runfolder, where MiSeq analysis output is deposited
+
+# The maximum error in a lane before filtering out bad tiles (%)
+MAX_LANE_ERROR: 2
+
+# The maximum error in a tile in a lane with too high error (%)
+MAX_TILE_ERROR: 2"""
+
+    QC_CONFIG = """<QCrequirements>
+	<platforms>
+		<platform>
+			<controlSoftware>HiSeq Control Software</controlSoftware>
+			<version>HiSeq Flow Cell v3</version>
+			<mode>HighOutput</mode>
+			<unidentified>20.0</unidentified>
+			<overridePoolingRequirement>0</overridePoolingRequirement>
+			<lengths>
+			</lengths>
+			<warning>
+				<unidentified>5.0</unidentified>
+				<numberOfCluster>140</numberOfCluster>
+				<overridePoolingRequirement>0</overridePoolingRequirement>
+				<lengths>
+					<l100>
+						<q30>11</q30>
+						<errorRate>2.0</errorRate>
+					</l100>
+					<l101>
+						<q30>11</q30>
+						<errorRate>2.0</errorRate>
+					</l101>
+					<l50>
+						<q30>5.6</q30>
+						<errorRate>1.0</errorRate>
+					</l50>
+					<l51>
+						<q30>5.6</q30>
+						<errorRate>1.0</errorRate>
+					</l51>
+				</lengths>
+			</warning>
+		</platform>
+		<platform>
+			<controlSoftware>HiSeq Control Software</controlSoftware>
+			<version>HiSeq Flow Cell v4</version>
+			<mode>RapidHighOutput</mode>
+			<unidentified>20.0</unidentified>
+			<overridePoolingRequirement>0</overridePoolingRequirement>
+			<lengths>
+			</lengths>
+			<warning>
+				<unidentified>10.0</unidentified>
+				<numberOfCluster>180</numberOfCluster>
+				<overridePoolingRequirement>0</overridePoolingRequirement>
+				<lengths>
+					<l125>
+						<q30>18</q30>
+						<errorRate>2.0</errorRate>
+					</l125>
+   					<l126>
+                         <q30>18</q30>
+                        <errorRate>2.0</errorRate>
+                    </l126>
+					<l100>
+						<q30>14</q30>
+						<errorRate>2.0</errorRate>
+					</l100>
+					<l101>
+						<q30>14</q30>
+						<errorRate>2.0</errorRate>
+					</l101>
+					<l50>
+						<q30>7.0</q30>
+						<errorRate>1.0</errorRate>
+					</l50>
+					<l51>
+						<q30>7.0</q30>
+						<errorRate>1.5</errorRate>
+					</l51>
+					<l62>
+						<q30>7.0</q30>
+						<errorRate>1.5</errorRate>
+					</l62>
+				</lengths>
+			</warning>
+		</platform>
+		 <platform>
+                        <controlSoftware>HiSeq X Control Software</controlSoftware>
+                        <version>HiSeq X HD v2</version>
+                        <unidentified>25.0</unidentified>
+                        <overridePoolingRequirement>0</overridePoolingRequirement>
+                        <lengths>
+                        </lengths>
+                        <warning>
+                                <unidentified>10.0</unidentified>
+                                <numberOfCluster>300</numberOfCluster>
+                                <overridePoolingRequirement>0</overridePoolingRequirement>
+                                <lengths>
+                                        <l151>
+                                                <q30>33.7</q30>
+                                                <errorRate>5.0</errorRate>
+                                        </l151>
+                                </lengths>
+                        </warning>
+                </platform>
+		<platform>
+			<controlSoftware>HiSeq Control Software</controlSoftware>
+			<version>HiSeq Rapid Flow Cell v1</version>
+			<mode>RapidRun</mode>
+			<unidentified>20.0</unidentified>
+			<overridePoolingRequirement>0</overridePoolingRequirement>
+			<lengths>
+			</lengths>
+			<warning>
+				<unidentified>10.0</unidentified>
+				<numberOfCluster>110</numberOfCluster>
+				<overridePoolingRequirement>0</overridePoolingRequirement>
+				<lengths>
+					<l151>
+						<q30>12.3</q30>
+						<errorRate>2.0</errorRate>
+					</l151>
+					<l101>
+						<q30>8.8</q30>
+						<errorRate>2.0</errorRate>
+					</l101>
+				</lengths>
+			</warning>
+		</platform>
+		<platform>
+			<controlSoftware>HiSeq Control Software</controlSoftware>
+			<version>HiSeq Rapid Flow Cell v2</version>
+			<mode>RapidRun</mode>
+			<unidentified>20.0</unidentified>
+			<overridePoolingRequirement>0</overridePoolingRequirement>
+			<lengths>
+			</lengths>
+			<warning>
+				<unidentified>10.0</unidentified>
+				<numberOfCluster>110</numberOfCluster>
+				<overridePoolingRequirement>0</overridePoolingRequirement>
+				<lengths>
+					<l251>
+						<q30>18.7</q30>
+						<errorRate>5.0</errorRate>
+					</l251>
+					<l250>
+						<q30>18.7</q30>
+						<errorRate>5.0</errorRate>
+					</l250>
+					<l151>
+						<q30>12.3</q30>
+						<errorRate>2.0</errorRate>
+					</l151>
+					<l101>
+						<q30>8.8</q30>
+						<errorRate>2.0</errorRate>
+					</l101>
+				</lengths>
+			</warning>
+		</platform>
+		<platform>
+			<controlSoftware>MiSeq Control Software</controlSoftware>
+			<version>Version2</version>
+			<unidentified>20.0</unidentified>
+			<overridePoolingRequirement>0</overridePoolingRequirement>
+			<lengths>
+			</lengths>
+			<warning>
+				<unidentified>10.0</unidentified>
+				<numberOfCluster>10</numberOfCluster>
+				<overridePoolingRequirement>0</overridePoolingRequirement>
+				<lengths>
+					<l251>
+						<q30>1.8</q30>
+						<errorRate>5.0</errorRate>
+					</l251>
+					<l151>
+						<q30>1.1</q30>
+						<errorRate>2.0</errorRate>
+					</l151>
+					<l26>
+						<q30>0.2</q30>
+						<errorRate>1.0</errorRate>
+					</l26>
+				</lengths>
+			</warning>
+		</platform>
+		<platform>
+			<controlSoftware>MiSeq Control Software</controlSoftware>
+			<version>Version3</version>
+			<unidentified>20.0</unidentified>
+			<overridePoolingRequirement>0</overridePoolingRequirement>
+			<lengths>
+			</lengths>
+			<warning>
+				<unidentified>10.0</unidentified>
+				<numberOfCluster>18</numberOfCluster>
+				<overridePoolingRequirement>0</overridePoolingRequirement>
+				<lengths>
+					<l301>
+						<q30>3.7</q30>
+						<errorRate>5.0</errorRate>
+					</l301>
+					<l75>
+						<q30>1.1</q30>
+						<errorRate>1.5</errorRate>
+					</l75>
+				</lengths>
+			</warning>
+		</platform>
+	</platforms>
+	<overrides>
+		<warning>
+			<lane1>
+			</lane1>
+		</warning>
+		<pass>
+			<lane1>
+			</lane1>
+		</pass>
+	</overrides>
+</QCrequirements>"""


### PR DESCRIPTION
Let the caller provide the Sisyphus and QC config as an input parameter in the HTTP body.
Also fixed some bugs with the semi-new/old requirement that HTTP output must be dicts and not lists.
