### PR TITLE
Include reason at error

### DIFF
--- a/siswrap/wrapper_services.py
+++ b/siswrap/wrapper_services.py
@@ -357,9 +357,11 @@ class ProcessService(object):
                 # killed off.
                 if wrapper.info.state is not State.ERROR:
                     out, err = proc.communicate()
-                    wrapper.info.msg = ("Process was completed successfully, "
+                    wrapper.info.msg = {"message": "Process was completed successfully, "
                                         "but encounted an error, with return "
-                                        "code {0}.").format(returncode)
+                                        "code {}.".format(returncode),
+                                        "stdout": out,
+                                        "stderr": err}
                     debugmsg = "Message was: " + err
                     wrapper.info.state = State.ERROR
             except OSError, err:
@@ -380,7 +382,7 @@ class ProcessService(object):
 
     def get_status(self, pid, wrapper_type):
         """ Get status of a specific process. Removes the pid from the queue
-            if the proecess has finished executing.
+            if the process has finished executing.
 
             Args:
                 pid: the pid of the process to check for

--- a/tests/integration/rest_tests.py
+++ b/tests/integration/rest_tests.py
@@ -10,6 +10,14 @@ from siswrap.siswrap import ProcessService
 # Recommended to have the environment variable ARTERIA_TEST set to 1
 # for the siswrap-wsd to test with a 1 min long running process
 
+#--------------------------------------------------
+# NOTE
+# These tests have not been maintained - and need
+# to be update before using them.
+# We should consider removing them in the future unless
+# they are updated.
+# /JD 20160224
+#--------------------------------------------------
 
 class TestRestApi(object):
     BASE_URL = "http://localhost:10900/api/1.0"


### PR DESCRIPTION
Siswrap should now return a message with stdout and stderr of the underlying process if it fail. This should be highly useful when debugging.
