### PR TITLE
- fixed broken pip install due to changed README.md filename

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     name='siswrap',
     version=__version__,
     description="Wrapper for the Sisyphus tools suite",
-    long_description=read_file('README'),
+    long_description=read_file('README.md'),
     keywords='bioinformatics',
     author='SNP&SEQ Technology Platform, Uppsala University',
     packages=find_packages(),


### PR DESCRIPTION
Pip install was broken, because it could no longer find the README due to the recent rename
